### PR TITLE
fix deprecation warning for usage of each

### DIFF
--- a/app/templates/components/growl-manager.hbs
+++ b/app/templates/components/growl-manager.hbs
@@ -1,4 +1,4 @@
 
-{{#each notification in notifications}}
+{{#each notifications as |norification|}}
   {{growl-instance action="dismiss" notification=notification}}
 {{/each}}


### PR DESCRIPTION
DEPRECATION: Using the '{{#each item in model}}' form of the {{#each}} helper ('appname/templates/components/growl-manager.hbs' @ L2:C0) is deprecated. Please use the block param form instead ('{{#each model as |item|}}'). See http://emberjs.com/guides/deprecations/#toc_code-in-code-syntax-for-code-each-code for more details.
        at /..emberapppath../bower_components/ember/ember-template-compiler.js:11705:36
